### PR TITLE
Fix entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
 COPY --from=builder /src/out /app
 
-CMD /app
+CMD ["/app"]


### PR DESCRIPTION
`CMD /app` launches via shell. `CMD ["/app"]` does not.